### PR TITLE
switch to % height for iOS positioning els

### DIFF
--- a/src/_base.scss
+++ b/src/_base.scss
@@ -48,6 +48,11 @@
   }
 }
 
+html.gist-active,
+body.gist-active {
+  height: 100%;
+}
+
 #gist-body {
   position: relative;
   z-index: $gist-body-index;
@@ -138,7 +143,7 @@ body.gist-landscape::before {
 .gist-beat {
   position: absolute;
   background-color: $beat-background;
-  height: 100vh;
+  height: 100%;
   width: 100%;
   display: flex;
   align-items: center;
@@ -432,7 +437,7 @@ body.gist-landscape::before {
 
 @if $pkg-gist {
   #gist-body {
-    height: 100vh;
+    height: 100%;
 
     [data-sg] {
       width: 100%;

--- a/src/js/init.js
+++ b/src/js/init.js
@@ -57,6 +57,7 @@ StoryGist.prototype.init = function () {
   // check dependencies
 
   var $body = $(self.element) // TODO: add to $els object
+  var $html = $('html')
   // var $loading = $('<div id="loading-screen"></div>')
   // $body.prepend($loading)
 
@@ -80,6 +81,7 @@ StoryGist.prototype.init = function () {
     // Hide the element that held the original content
     $originalStoryContent.css('display', 'none')
     $body.addClass('gist-active')
+    $html.addClass('gist-active')
 
     gistEls.each((i, el) => {
       // Create a new object for our beat

--- a/src/pkggist.scss
+++ b/src/pkggist.scss
@@ -18,6 +18,7 @@ a {
 .pkg-beat {
   background-color: $pkg-beat-background;
   position: relative;
+  height: 100%;
 
   & > img,
   & > video {


### PR DESCRIPTION
- 100vh to 100%, properly sets the beat height to visible height rather than screen height which goes beyond safari browser chrome.

![image](https://user-images.githubusercontent.com/952321/28287448-b9ac35a2-6b09-11e7-803f-2f4ac84c29df.png)
